### PR TITLE
#ifdef MAP_32BIT for the 64bit case only

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -56,7 +56,9 @@ static int mmap_prot_flags[] = {
 };
 
 static int mmap_flags[] = {
+#ifdef __LP64__
 	MAP_32BIT,
+#endif
 	MAP_ALIGNED_SUPER,
 	MAP_ANON,
 	MAP_FIXED,


### PR DESCRIPTION
As seen in sys/mman.h.
This makes it possible to build on i386.